### PR TITLE
Map impovement #1

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -1008,6 +1008,9 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue,
+/obj/effect/spawner/lootdrop/armory_contraband,
+/obj/effect/spawner/lootdrop/armory_contraband,
+/obj/effect/spawner/lootdrop/armory_contraband,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "afe" = (
@@ -42509,6 +42512,12 @@
 /obj/structure/closet/boxinggloves,
 /turf/open/floor/plasteel,
 /area/commons/fitness)
+"cEu" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 6
+	},
+/turf/open/floor/glass/reinforced,
+/area/commons/dorms)
 "cGf" = (
 /obj/item/radio/intercom{
 	name = "Station Intercom (General)";
@@ -43733,6 +43742,12 @@
 	},
 /turf/closed/wall,
 /area/service/chapel/office)
+"cYL" = (
+/obj/structure/alien/weeds,
+/obj/structure/alien/egg/burst,
+/obj/structure/alien/weeds/node,
+/turf/open/space/basic,
+/area/commons/dorms)
 "cZe" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -44961,13 +44976,7 @@
 /turf/open/floor/plasteel/dark,
 /area/service/hydroponics)
 "dYf" = (
-/obj/structure/toilet/secret/low_loot{
-	dir = 8
-	},
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/mineral/titanium/blue,
+/turf/open/floor/glass/reinforced,
 /area/commons/dorms)
 "dYl" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -45041,6 +45050,13 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/open/floor/plasteel/dark,
 /area/security/execution/transfer)
+"ebB" = (
+/obj/structure/alien/weeds,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 6
+	},
+/turf/open/space/basic,
+/area/commons/dorms)
 "ebD" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -45210,6 +45226,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
+"ejS" = (
+/obj/effect/overlay/palmtree_l,
+/turf/open/floor/grass,
+/area/commons/dorms)
 "ejT" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Psychology Office Maintenance";
@@ -46065,11 +46085,11 @@
 "eZe" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock{
-	id_tag = "Dorm7";
-	name = "Room Seven"
-	},
 /obj/structure/fans/tiny/invisible,
+/obj/machinery/door/airlock/external{
+	id_tag = "Space Dorms";
+	name = "Space Dorms"
+	},
 /turf/open/floor/carpet,
 /area/commons/dorms)
 "faI" = (
@@ -46167,17 +46187,23 @@
 	},
 /turf/open/floor/carpet,
 /area/service/library)
+"fdw" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 6
+	},
+/turf/open/floor/grass,
+/area/commons/dorms)
 "fdH" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/button/door{
-	id = "Dorm12";
-	name = "Cabin Bolt Control";
-	normaldoorcontrol = 1;
-	pixel_x = 25;
-	specialfunctions = 4
-	},
 /obj/structure/fireplace{
 	pixel_y = -6
+	},
+/obj/machinery/button/door{
+	id = "Dorm9";
+	name = "Cabin Bolt Control";
+	normaldoorcontrol = 1;
+	specialfunctions = 4;
+	pixel_x = 25
 	},
 /turf/open/floor/carpet,
 /area/commons/dorms)
@@ -46683,6 +46709,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison/upper)
+"fAi" = (
+/obj/structure/alien/weeds,
+/obj/structure/alien/egg/burst,
+/obj/structure/alien/weeds/node,
+/obj/item/clothing/mask/facehugger/impregnated,
+/turf/open/space/basic,
+/area/commons/dorms)
 "fAj" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
@@ -48384,13 +48417,13 @@
 /turf/open/floor/wood/wood_diagonal,
 /area/security/prison/upper)
 "gUt" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/obj/structure/alien/weeds,
 /obj/structure/closet/secure_closet/personal/cabinet,
-/obj/machinery/light/small{
-	brightness = 3;
-	dir = 8
+/obj/structure/window/reinforced/tinted{
+	dir = 1
 	},
-/turf/open/floor/carpet,
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/turf/open/space/basic,
 /area/commons/dorms)
 "gUu" = (
 /obj/structure/lattice,
@@ -48410,20 +48443,22 @@
 /turf/open/floor/plating,
 /area/construction)
 "gWm" = (
+/obj/structure/alien/weeds,
+/obj/structure/table/wood/fancy/black,
+/obj/structure/window/reinforced/tinted{
+	dir = 1
+	},
 /obj/machinery/button/door{
-	id = "Dorm8";
-	name = "Cabin Bolt Control";
+	id = "Xeno Dorms";
+	name = "Door Bolt Control";
 	normaldoorcontrol = 1;
 	pixel_y = -25;
 	specialfunctions = 4
 	},
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 23
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 8
 	},
-/obj/structure/bed/double,
-/obj/item/bedsheet/random/double,
-/turf/open/floor/carpet,
+/turf/open/space/basic,
 /area/commons/dorms)
 "gXs" = (
 /obj/structure/lattice,
@@ -50315,11 +50350,11 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock{
-	id_tag = "Dorm10";
-	name = "Room Ten"
-	},
 /obj/structure/fans/tiny/invisible,
+/obj/machinery/door/airlock{
+	id_tag = "Dorm7";
+	name = "Room Seven"
+	},
 /turf/open/floor/carpet,
 /area/commons/dorms)
 "iRV" = (
@@ -50999,15 +51034,15 @@
 /area/security/prison/upper)
 "jsw" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/fireplace{
+	pixel_y = -6
+	},
 /obj/machinery/button/door{
-	id = "Dorm13";
+	id = "Dorm10";
 	name = "Cabin Bolt Control";
 	normaldoorcontrol = 1;
 	pixel_x = 25;
 	specialfunctions = 4
-	},
-/obj/structure/fireplace{
-	pixel_y = -6
 	},
 /turf/open/floor/carpet,
 /area/commons/dorms)
@@ -52086,8 +52121,8 @@
 /turf/open/floor/carpet/royalblack,
 /area/service/library)
 "kmx" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/carpet,
+/obj/structure/alien/weeds,
+/turf/open/space/basic,
 /area/commons/dorms)
 "knm" = (
 /obj/effect/turf_decal/tile/blue{
@@ -52832,8 +52867,10 @@
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
 "kTT" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
-/turf/open/floor/carpet,
+/obj/structure/window/reinforced/tinted{
+	dir = 1
+	},
+/turf/open/floor/glass/reinforced,
 /area/commons/dorms)
 "kUn" = (
 /obj/machinery/door/airlock/external{
@@ -53714,6 +53751,13 @@
 /obj/item/kirbyplants/brass,
 /turf/open/floor/wood/wood_large,
 /area/service/chapel/main)
+"lHU" = (
+/obj/structure/alien/weeds,
+/obj/structure/window/reinforced/tinted{
+	dir = 1
+	},
+/turf/open/space/basic,
+/area/commons/dorms)
 "lIg" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 10
@@ -54936,6 +54980,13 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/service/hydroponics)
+"mNg" = (
+/obj/structure/table/wood/mushroom,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/grass,
+/area/commons/dorms)
 "mNi" = (
 /obj/machinery/light_switch{
 	pixel_x = -20
@@ -55305,6 +55356,14 @@
 /obj/effect/landmark/observer_start,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"ngb" = (
+/obj/structure/closet/secure_closet/personal/cabinet,
+/obj/structure/window/reinforced/tinted{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/turf/open/floor/glass/reinforced,
+/area/commons/dorms)
 "ngs" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -55382,6 +55441,11 @@
 	},
 /turf/open/floor/engine,
 /area/maintenance/disposal/incinerator)
+"nnd" = (
+/obj/structure/alien/weeds,
+/obj/structure/bed/nest,
+/turf/open/space/basic,
+/area/commons/dorms)
 "nnp" = (
 /obj/structure/closet/secure_closet/medical1,
 /obj/effect/decal/cleanable/dirt,
@@ -56602,6 +56666,13 @@
 	},
 /turf/open/floor/grass,
 /area/security/prison/upper)
+"ooO" = (
+/obj/structure/chair/comfy/plywood{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/turf/open/floor/grass,
+/area/commons/dorms)
 "ooP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -56908,12 +56979,9 @@
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
 "oyO" = (
-/obj/structure/dresser,
-/obj/item/flashlight/lamp/green{
-	pixel_x = -2;
-	pixel_y = 15
-	},
-/turf/open/floor/carpet,
+/obj/structure/alien/weeds,
+/obj/structure/window/reinforced/tinted,
+/turf/open/space/basic,
 /area/commons/dorms)
 "oyX" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
@@ -56952,10 +57020,7 @@
 /turf/open/floor/carpet/purple,
 /area/command/bridge)
 "oAB" = (
-/obj/structure/fireplace{
-	pixel_y = -6
-	},
-/turf/open/floor/carpet,
+/turf/open/floor/grass,
 /area/commons/dorms)
 "oAT" = (
 /obj/effect/turf_decal/tile/bar,
@@ -57195,15 +57260,15 @@
 /area/space)
 "oLK" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/button/door{
-	id = "Dorm11";
-	name = "Cabin Bolt Control";
-	normaldoorcontrol = 1;
-	pixel_x = 25;
-	specialfunctions = 4
-	},
 /obj/structure/fireplace{
 	pixel_y = -6
+	},
+/obj/machinery/button/door{
+	id = "Dorm8";
+	name = "Cabin Bolt Control";
+	normaldoorcontrol = 1;
+	specialfunctions = 4;
+	pixel_x = 25
 	},
 /turf/open/floor/carpet,
 /area/commons/dorms)
@@ -57568,15 +57633,15 @@
 /area/security/prison/cells)
 "pkt" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/button/door{
-	id = "Dorm10";
-	name = "Cabin Bolt Control";
-	normaldoorcontrol = 1;
-	pixel_x = 25;
-	specialfunctions = 4
-	},
 /obj/structure/fireplace{
 	pixel_y = -6
+	},
+/obj/machinery/button/door{
+	id = "Dorm7";
+	name = "Cabin Bolt Control";
+	normaldoorcontrol = 1;
+	specialfunctions = 4;
+	pixel_x = 25
 	},
 /turf/open/floor/carpet,
 /area/commons/dorms)
@@ -57596,13 +57661,8 @@
 /turf/open/floor/plasteel/dark,
 /area/maintenance/starboard/aft)
 "pmE" = (
-/obj/structure/sink{
-	pixel_y = 25
-	},
-/obj/structure/mirror{
-	pixel_y = 32
-	},
-/turf/open/floor/mineral/titanium/blue,
+/obj/structure/bed/badhaybed,
+/turf/open/floor/grass,
 /area/commons/dorms)
 "pnc" = (
 /obj/effect/turf_decal/tile/blue,
@@ -58841,20 +58901,21 @@
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
 "qqG" = (
+/obj/structure/table/wood/fancy/black,
+/obj/structure/window/reinforced/tinted{
+	dir = 1
+	},
 /obj/machinery/button/door{
-	id = "Dorm7";
-	name = "Cabin Bolt Control";
+	id = "Space Dorms";
+	name = "Door Bolt Control";
 	normaldoorcontrol = 1;
 	pixel_y = -25;
 	specialfunctions = 4
 	},
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 23
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 8
 	},
-/obj/structure/bed/double,
-/obj/item/bedsheet/random/double,
-/turf/open/floor/carpet,
+/turf/open/floor/glass/reinforced,
 /area/commons/dorms)
 "qrq" = (
 /obj/structure/toilet/secret/low_loot{
@@ -59025,20 +59086,18 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "qBD" = (
+/obj/structure/closet/secure_closet/personal/cabinet,
 /obj/machinery/button/door{
-	id = "Dorm9";
-	name = "Cabin Bolt Control";
+	id = "Oasis Dorms";
+	name = "Door Bolt Control";
 	normaldoorcontrol = 1;
 	pixel_y = -25;
 	specialfunctions = 4
 	},
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 23
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 8
 	},
-/obj/item/bedsheet/random/double,
-/obj/structure/bed/double,
-/turf/open/floor/carpet,
+/turf/open/floor/grass,
 /area/commons/dorms)
 "qBR" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -59178,11 +59237,11 @@
 "qGW" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock{
-	id_tag = "Dorm8";
-	name = "Room Eight"
-	},
 /obj/structure/fans/tiny/invisible,
+/obj/machinery/door/airlock{
+	id_tag = "Xeno Dorms";
+	name = "Xeno Dorms"
+	},
 /turf/open/floor/carpet,
 /area/commons/dorms)
 "qHH" = (
@@ -59853,6 +59912,14 @@
 /obj/structure/closet/firecloset,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"rlF" = (
+/obj/structure/bed/shadow,
+/obj/item/bedsheet/cosmos,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/glass/reinforced,
+/area/commons/dorms)
 "rmQ" = (
 /obj/machinery/portable_atmospherics/scrubber,
 /obj/effect/turf_decal/stripes/line{
@@ -60063,11 +60130,11 @@
 "ryP" = (
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock{
-	id_tag = "Dorm12";
-	name = "Room Twelve"
-	},
 /obj/structure/fans/tiny/invisible,
+/obj/machinery/door/airlock{
+	id_tag = "Dorm9";
+	name = "Room Nine"
+	},
 /turf/open/floor/carpet,
 /area/commons/dorms)
 "rAe" = (
@@ -60340,6 +60407,10 @@
 	},
 /turf/open/floor/mineral/titanium/blue,
 /area/commons/toilet)
+"rMK" = (
+/obj/structure/chair/comfy/plywood,
+/turf/open/floor/grass,
+/area/commons/dorms)
 "rML" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -62202,6 +62273,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"tvL" = (
+/obj/structure/window/reinforced/tinted,
+/turf/open/floor/glass/reinforced,
+/area/commons/dorms)
 "tvT" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -62543,11 +62618,11 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock{
-	id_tag = "Dorm13";
-	name = "Room Thirteen"
-	},
 /obj/structure/fans/tiny/invisible,
+/obj/machinery/door/airlock{
+	id_tag = "Dorm10";
+	name = "Room Ten"
+	},
 /turf/open/floor/carpet,
 /area/commons/dorms)
 "tKE" = (
@@ -65750,11 +65825,11 @@
 "wqv" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock{
-	id_tag = "Dorm9";
-	name = "Room Nine"
-	},
 /obj/structure/fans/tiny/invisible,
+/obj/machinery/door/airlock{
+	id_tag = "Oasis Dorms";
+	name = "Oasis Dorms"
+	},
 /turf/open/floor/carpet,
 /area/commons/dorms)
 "wqR" = (
@@ -66637,6 +66712,10 @@
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/plasteel/grimy,
 /area/hallway/secondary/entry)
+"xnj" = (
+/obj/effect/overlay/palmtree_r,
+/turf/open/floor/grass,
+/area/commons/dorms)
 "xnU" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/red{
@@ -67618,11 +67697,11 @@
 "yeB" = (
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock{
-	id_tag = "Dorm11";
-	name = "Room Eleven"
-	},
 /obj/structure/fans/tiny/invisible,
+/obj/machinery/door/airlock{
+	id_tag = "Dorm8";
+	name = "Room Eight"
+	},
 /turf/open/floor/carpet,
 /area/commons/dorms)
 "yeH" = (
@@ -104879,10 +104958,10 @@ fha
 att
 tAo
 nFz
-gne
-arf
-oyO
-gUt
+dYf
+dYf
+tvL
+ngb
 vyp
 qrM
 mGF
@@ -105136,10 +105215,10 @@ fHG
 fHG
 arj
 arj
-pmE
-gzf
+rlF
+tvL
 kTT
-kmx
+cEu
 eZe
 fZY
 flw
@@ -105394,8 +105473,8 @@ fHG
 nRy
 arj
 dYf
-arf
-oAB
+dYf
+tvL
 qqG
 arf
 oHB
@@ -105907,8 +105986,8 @@ fHG
 fHG
 eNm
 arj
-gne
-arf
+cYL
+kmx
 oyO
 gUt
 vyp
@@ -106164,10 +106243,10 @@ fHG
 fHG
 wmH
 arj
-pmE
-gzf
-kTT
-kmx
+nnd
+oyO
+lHU
+ebB
 qGW
 fZY
 flw
@@ -106421,9 +106500,9 @@ fHG
 fHG
 arj
 arj
-dYf
-arf
-oAB
+fAi
+kmx
+oyO
 gWm
 arf
 oHB
@@ -106935,10 +107014,10 @@ arj
 arj
 leO
 arj
-gne
-arf
-oyO
-gUt
+ejS
+rMK
+mNg
+ooO
 vyp
 xYx
 mGF
@@ -107193,9 +107272,9 @@ alP
 anf
 arf
 pmE
-gzf
-kTT
-kmx
+oAB
+oAB
+fdw
 wqv
 fZY
 wjU
@@ -107449,8 +107528,8 @@ aaa
 alP
 anf
 arf
-dYf
-arf
+xnj
+oAB
 oAB
 qBD
 arf

--- a/_maps/map_files/CogStation/CogStation.dmm
+++ b/_maps/map_files/CogStation/CogStation.dmm
@@ -196,6 +196,8 @@
 /obj/item/storage/box/firingpins,
 /obj/item/storage/box/firingpins,
 /obj/effect/spawner/lootdrop/armory_contraband/metastation,
+/obj/effect/spawner/lootdrop/armory_contraband,
+/obj/effect/spawner/lootdrop/armory_contraband,
 /turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
 "aaD" = (

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -22543,6 +22543,10 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/effect/spawner/lootdrop/armory_contraband,
+/obj/effect/spawner/lootdrop/armory_contraband,
+/obj/effect/spawner/lootdrop/armory_contraband,
+/obj/effect/spawner/lootdrop/armory_contraband,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "bPC" = (

--- a/_maps/map_files/FestiveBall/FestiveStation.dmm
+++ b/_maps/map_files/FestiveBall/FestiveStation.dmm
@@ -2641,7 +2641,7 @@
 	},
 /obj/item/clothing/under/syndicate/baseball,
 /obj/item/clothing/head/beret/sec{
-	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0);
+	armor = list("melee"=0,"bullet"=0,"laser"=0,"energy"=0,"bomb"=0,"bio"=0,"rad"=0);
 	desc = "A replica beret resembling that of a special operations officer under Nanotrasen.";
 	name = "replica officer's beret"
 	},
@@ -2658,7 +2658,7 @@
 	dir = 4
 	},
 /obj/item/clothing/head/centhat{
-	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0);
+	armor = list("melee"=0,"bullet"=0,"laser"=0,"energy"=0,"bomb"=0,"bio"=0,"rad"=0);
 	desc = "A replica hat of a Central Commander's attire. It has a small tag on it saying, 'It's good to be emperor.'";
 	name = "Replica CentCom hat"
 	},
@@ -5474,6 +5474,9 @@
 	pixel_y = 23
 	},
 /obj/structure/closet/secure_closet/contraband/armory,
+/obj/effect/spawner/lootdrop/armory_contraband,
+/obj/effect/spawner/lootdrop/armory_contraband,
+/obj/effect/spawner/lootdrop/armory_contraband,
 /turf/open/floor/festive/wooden/wooden1,
 /area/ai_monitored/security/armory)
 "aoa" = (
@@ -35556,7 +35559,7 @@
 /obj/machinery/vending/dinnerware{
 	desc = "A vending machine stocked full of condiments to put on food.";
 	name = "\improper Condiments Dispenser";
-	products = list(/obj/item/storage/bag/tray = 10, /obj/item/kitchen/fork = 6, /obj/item/kitchen/knife = 6, /obj/item/reagent_containers/food/drinks/drinkingglass = 20, /obj/item/clothing/suit/apron/chef = 2, /obj/item/storage/box/cups = 10, /obj/item/reagent_containers/food/condiment/pack/ketchup = 20, /obj/item/reagent_containers/food/condiment/pack/mustard = 20, /obj/item/reagent_containers/food/condiment/pack/hotsauce = 20, /obj/item/reagent_containers/food/condiment/pack/astrotame = 20, /obj/item/reagent_containers/food/condiment/saltshaker = 20, /obj/item/reagent_containers/food/condiment/peppermill = 20, /obj/item/reagent_containers/glass/bowl = 30)
+	products = list(/obj/item/storage/bag/tray=10,/obj/item/kitchen/fork=6,/obj/item/kitchen/knife=6,/obj/item/reagent_containers/food/drinks/drinkingglass=20,/obj/item/clothing/suit/apron/chef=2,/obj/item/storage/box/cups=10,/obj/item/reagent_containers/food/condiment/pack/ketchup=20,/obj/item/reagent_containers/food/condiment/pack/mustard=20,/obj/item/reagent_containers/food/condiment/pack/hotsauce=20,/obj/item/reagent_containers/food/condiment/pack/astrotame=20,/obj/item/reagent_containers/food/condiment/saltshaker=20,/obj/item/reagent_containers/food/condiment/peppermill=20,/obj/item/reagent_containers/glass/bowl=30)
 	},
 /turf/open/floor/wood,
 /area/service/bar/atrium)
@@ -43307,42 +43310,42 @@
 	},
 /obj/item/reagent_containers/food/condiment/flour{
 	desc = "A large sack of flour for restaurants, not the home-baker!";
-	list_reagents = list(/datum/reagent/consumable/flour = 90);
+	list_reagents = list(/datum/reagent/consumable/flour=90);
 	name = "Large Flour Sack"
 	},
 /obj/item/reagent_containers/food/condiment/flour{
 	desc = "A large sack of flour for restaurants, not the home-baker!";
-	list_reagents = list(/datum/reagent/consumable/flour = 90);
+	list_reagents = list(/datum/reagent/consumable/flour=90);
 	name = "Large Flour Sack"
 	},
 /obj/item/reagent_containers/food/condiment/flour{
 	desc = "A large sack of flour for restaurants, not the home-baker!";
-	list_reagents = list(/datum/reagent/consumable/flour = 90);
+	list_reagents = list(/datum/reagent/consumable/flour=90);
 	name = "Large Flour Sack"
 	},
 /obj/item/reagent_containers/food/condiment/flour{
 	desc = "A large sack of flour for restaurants, not the home-baker!";
-	list_reagents = list(/datum/reagent/consumable/flour = 90);
+	list_reagents = list(/datum/reagent/consumable/flour=90);
 	name = "Large Flour Sack"
 	},
 /obj/item/reagent_containers/food/condiment/rice{
 	desc = "A huge sack of rice. Probably for restaurants that actually go through such a huge volume of it easily, not for the home cook.";
-	list_reagents = list(/datum/reagent/consumable/rice = 90);
+	list_reagents = list(/datum/reagent/consumable/rice=90);
 	name = "Large Rice Sack"
 	},
 /obj/item/reagent_containers/food/condiment/rice{
 	desc = "A huge sack of rice. Probably for restaurants that actually go through such a huge volume of it easily, not for the home cook.";
-	list_reagents = list(/datum/reagent/consumable/rice = 90);
+	list_reagents = list(/datum/reagent/consumable/rice=90);
 	name = "Large Rice Sack"
 	},
 /obj/item/reagent_containers/food/condiment/rice{
 	desc = "A huge sack of rice. Probably for restaurants that actually go through such a huge volume of it easily, not for the home cook.";
-	list_reagents = list(/datum/reagent/consumable/rice = 90);
+	list_reagents = list(/datum/reagent/consumable/rice=90);
 	name = "Large Rice Sack"
 	},
 /obj/item/reagent_containers/food/condiment/rice{
 	desc = "A huge sack of rice. Probably for restaurants that actually go through such a huge volume of it easily, not for the home cook.";
-	list_reagents = list(/datum/reagent/consumable/rice = 90);
+	list_reagents = list(/datum/reagent/consumable/rice=90);
 	name = "Large Rice Sack"
 	},
 /turf/open/floor/plasteel/freezer,

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -6082,6 +6082,9 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/bot,
+/obj/effect/spawner/lootdrop/armory_contraband,
+/obj/effect/spawner/lootdrop/armory_contraband,
+/obj/effect/spawner/lootdrop/armory_contraband,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "akD" = (

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -8007,9 +8007,14 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "ayR" = (
-/obj/item/wrench,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/obj/structure/window/reinforced/tinted{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/glass/reinforced,
+/area/commons/dorms)
 "azb" = (
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
 /obj/structure/cable/yellow{
@@ -8369,7 +8374,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/structure/grille,
+/obj/item/wrench,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "aAn" = (
@@ -9778,14 +9783,10 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "aHW" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plating{
-	icon_state = "platingdmg3"
-	},
-/area/maintenance/starboard/fore)
+/obj/structure/bed/shadow,
+/obj/item/bedsheet/cosmos,
+/turf/open/floor/glass/reinforced,
+/area/commons/dorms)
 "aIf" = (
 /obj/machinery/camera{
 	c_tag = "Auxillary Base Construction";
@@ -10250,15 +10251,10 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "aLk" = (
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 6
-	},
-/obj/item/cigbutt,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/obj/structure/alien/weeds,
+/obj/structure/bed/nest,
+/turf/open/space/basic,
+/area/commons/dorms)
 "aLo" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -10570,15 +10566,11 @@
 /turf/open/space,
 /area/space/nearstation)
 "aNS" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/yellow{
-	icon_state = "2-8"
+	icon_state = "1-2"
 	},
-/turf/open/floor/plating{
-	icon_state = "platingdmg3"
-	},
+/turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "aNZ" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -46599,6 +46591,13 @@
 	},
 /turf/open/floor/plating,
 /area/commons/toilet/auxiliary)
+"dkM" = (
+/obj/structure/alien/weeds,
+/obj/structure/alien/egg/burst,
+/obj/item/clothing/mask/facehugger/impregnated,
+/obj/structure/alien/weeds/node,
+/turf/open/space/basic,
+/area/commons/dorms)
 "dkX" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /obj/structure/disposalpipe/segment{
@@ -50995,12 +50994,12 @@
 /turf/open/floor/plasteel,
 /area/cargo/storage)
 "fbw" = (
-/obj/machinery/door/airlock{
-	id_tag = "Cabin3";
-	name = "Cabin 6"
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
+	},
+/obj/machinery/door/airlock{
+	id_tag = "Cabin2";
+	name = "Cabin 4"
 	},
 /turf/open/floor/wood,
 /area/commons/dorms)
@@ -51828,7 +51827,7 @@
 "fEl" = (
 /obj/structure/bed,
 /obj/machinery/button/door{
-	id = "Cabin5";
+	id = "Cabin7";
 	name = "Dorm Bolt Control";
 	normaldoorcontrol = 1;
 	pixel_x = -25;
@@ -55599,12 +55598,12 @@
 /turf/open/floor/plasteel/grimy,
 /area/service/chapel/office)
 "hKK" = (
-/obj/machinery/door/airlock{
-	id_tag = "Cabin5";
-	name = "Cabin 3"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
+	},
+/obj/machinery/door/airlock{
+	id_tag = "Cabin7";
+	name = "Cabin 1"
 	},
 /turf/open/floor/wood,
 /area/commons/dorms)
@@ -56660,12 +56659,13 @@
 /turf/open/floor/engine,
 /area/engineering/main)
 "ikA" = (
-/obj/structure/closet/secure_closet/personal/cabinet,
-/obj/machinery/airalarm{
-	pixel_y = 23
+/obj/structure/window/reinforced/tinted{
+	dir = 4;
+	pixel_x = 4
 	},
-/obj/item/clothing/under/suit/navy,
-/turf/open/floor/carpet,
+/obj/structure/table/wood/fancy/black,
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/turf/open/floor/glass/reinforced,
 /area/commons/dorms)
 "ilE" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/nitrogen_output{
@@ -56996,17 +56996,11 @@
 /turf/open/floor/plasteel,
 /area/cargo/storage)
 "iwd" = (
-/obj/effect/landmark/xeno_spawn,
-/obj/machinery/airalarm{
-	pixel_y = 23
+/obj/structure/alien/weeds,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 10
 	},
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
-	},
-/turf/open/floor/wood,
+/turf/open/space/basic,
 /area/commons/dorms)
 "iwg" = (
 /obj/structure/sign/warning/pods,
@@ -57834,19 +57828,12 @@
 	},
 /area/engineering/main)
 "iTC" = (
-/obj/machinery/button/door{
-	id = "Cabin7";
-	name = "Door Bolt Control";
-	normaldoorcontrol = 1;
-	pixel_x = -25;
-	specialfunctions = 4
-	},
-/obj/structure/bed,
+/obj/structure/alien/weeds,
+/obj/structure/closet/secure_closet/personal/cabinet,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
 	},
-/obj/effect/spawner/lootdrop/bedsheet,
-/turf/open/floor/wood,
+/turf/open/space/basic,
 /area/commons/dorms)
 "iUm" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -60504,10 +60491,10 @@
 /turf/open/floor/plasteel/dark/corner,
 /area/engineering/break_room)
 "kum" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 9
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/glass/reinforced,
 /area/commons/dorms)
 "kuG" = (
 /obj/structure/sign/map/left{
@@ -60651,8 +60638,7 @@
 	},
 /area/service/chapel/main)
 "kyr" = (
-/obj/machinery/light/small,
-/turf/open/floor/carpet,
+/turf/open/floor/glass/reinforced,
 /area/commons/dorms)
 "kyt" = (
 /obj/machinery/button/door{
@@ -61833,10 +61819,17 @@
 /turf/open/floor/plasteel,
 /area/commons/locker)
 "kZv" = (
-/obj/structure/chair/wood/normal{
-	dir = 4
+/obj/structure/alien/weeds,
+/obj/structure/window/reinforced/tinted{
+	dir = 4;
+	pixel_x = 4
 	},
-/turf/open/floor/wood,
+/obj/structure/table/wood/fancy/black,
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1;
+	pixel_x = 5
+	},
+/turf/open/space/basic,
 /area/commons/dorms)
 "kZR" = (
 /obj/item/storage/book/bible,
@@ -64849,11 +64842,17 @@
 /turf/open/floor/wood,
 /area/service/library)
 "mHZ" = (
-/obj/effect/landmark/xeno_spawn,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/carpet,
+/obj/machinery/button/door{
+	id = "Space Dorms";
+	name = "Door Bolt Control";
+	normaldoorcontrol = 1;
+	pixel_y = -25;
+	specialfunctions = 4
+	},
+/turf/open/floor/glass/reinforced,
 /area/commons/dorms)
 "mIt" = (
 /obj/structure/showcase/cyborg/old{
@@ -66136,12 +66135,12 @@
 /turf/open/floor/engine,
 /area/engineering/main)
 "nyg" = (
-/obj/machinery/door/airlock{
-	id_tag = "Cabin4";
-	name = "Cabin 5"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
+	},
+/obj/machinery/door/airlock{
+	id_tag = "Cabin6";
+	name = "Cabin 2"
 	},
 /turf/open/floor/wood,
 /area/commons/dorms)
@@ -69081,6 +69080,10 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/engineering/main)
+"pas" = (
+/obj/effect/landmark/blobstart,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "paA" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -69120,9 +69123,8 @@
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
 "paQ" = (
-/obj/structure/closet/secure_closet/personal/cabinet,
-/obj/item/clothing/under/misc/assistantformal,
-/turf/open/floor/wood,
+/obj/structure/alien/weeds,
+/turf/open/space/basic,
 /area/commons/dorms)
 "paS" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -74179,7 +74181,7 @@
 	},
 /obj/effect/decal/cleanable/cobweb,
 /obj/machinery/button/door{
-	id = "Cabin4";
+	id = "Cabin6";
 	name = "Cabin Bolt Control";
 	normaldoorcontrol = 1;
 	pixel_x = -25;
@@ -74260,10 +74262,18 @@
 	},
 /area/service/chapel/main)
 "rJO" = (
+/obj/structure/alien/weeds,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/wood,
+/obj/machinery/button/door{
+	id = "Xeno Dorms";
+	name = "Door Bolt Control";
+	normaldoorcontrol = 1;
+	specialfunctions = 4;
+	pixel_y = 25
+	},
+/turf/open/space/basic,
 /area/commons/dorms)
 "rJT" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -80689,13 +80699,11 @@
 /turf/open/floor/carpet,
 /area/service/theater)
 "vqv" = (
-/obj/structure/table/wood,
-/obj/machinery/newscaster{
-	pixel_x = 29;
-	pixel_y = 1
+/obj/structure/alien/weeds,
+/obj/structure/window/reinforced/tinted{
+	dir = 8
 	},
-/obj/item/paper,
-/turf/open/floor/wood,
+/turf/open/space/basic,
 /area/commons/dorms)
 "vqN" = (
 /obj/machinery/gateway/centerstation{
@@ -82458,20 +82466,11 @@
 /turf/open/floor/plasteel/dark,
 /area/engineering/main)
 "wpD" = (
-/obj/structure/bed,
-/obj/machinery/button/door{
-	id = "Cabin6";
-	name = "Dorm Bolt Control";
-	normaldoorcontrol = 1;
-	pixel_x = -25;
-	specialfunctions = 4
-	},
-/obj/effect/decal/cleanable/cobweb,
+/obj/structure/closet/secure_closet/personal/cabinet,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
 	},
-/obj/effect/spawner/lootdrop/bedsheet,
-/turf/open/floor/carpet,
+/turf/open/floor/glass/reinforced,
 /area/commons/dorms)
 "wpE" = (
 /obj/machinery/smartfridge/drinks{
@@ -84237,12 +84236,12 @@
 /turf/closed/wall/r_wall,
 /area/command/heads_quarters/captain/private)
 "xhM" = (
-/obj/machinery/door/airlock{
-	id_tag = "Cabin2";
-	name = "Cabin 4"
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
+	},
+/obj/machinery/door/airlock{
+	id_tag = "Cabin5";
+	name = "Cabin 3"
 	},
 /turf/open/floor/wood,
 /area/commons/dorms)
@@ -85208,7 +85207,7 @@
 "xGy" = (
 /obj/structure/bed,
 /obj/machinery/button/door{
-	id = "Cabin3";
+	id = "Cabin2";
 	name = "Cabin Bolt Control";
 	normaldoorcontrol = 1;
 	pixel_x = 25;
@@ -124129,7 +124128,7 @@ jBn
 wfx
 aAl
 wfx
-nqK
+ayR
 kyr
 wfx
 paQ
@@ -124386,11 +124385,11 @@ wfx
 wfx
 aHQ
 wfx
+aHW
+kyr
 wfx
-wfx
-wfx
-wfx
-wfx
+aLk
+dkM
 pSY
 pSY
 pSY
@@ -124643,11 +124642,11 @@ axL
 dnh
 axO
 dnh
-dhB
-aLk
-aHW
-aYa
-aHV
+dnh
+dnh
+dnh
+dnh
+dnh
 dnh
 aKw
 aLZ
@@ -124901,10 +124900,10 @@ ayQ
 aAn
 aIv
 aCM
-avF
-aLJ
 aNS
-aHW
+aNS
+aNS
+aCM
 dhH
 aCM
 aCM
@@ -125668,7 +125667,7 @@ bai
 ate
 dDL
 axP
-dnS
+pas
 ocS
 pUr
 lmt
@@ -125925,7 +125924,7 @@ aus
 dnS
 dnh
 aAm
-dnS
+aLJ
 ocS
 owQ
 gua
@@ -126182,7 +126181,7 @@ dnh
 dnh
 dnh
 axQ
-ayR
+aHV
 ocS
 yaU
 ygd
@@ -126439,7 +126438,7 @@ dCi
 dnS
 dnS
 axO
-dnS
+dhB
 ocS
 rCK
 xel

--- a/_maps/map_files/OmegaStation/OmegaStation.dmm
+++ b/_maps/map_files/OmegaStation/OmegaStation.dmm
@@ -9041,6 +9041,10 @@
 	},
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/closet/secure_closet/contraband/armory,
+/obj/effect/spawner/lootdrop/armory_contraband,
+/obj/effect/spawner/lootdrop/armory_contraband,
+/obj/effect/spawner/lootdrop/armory_contraband,
+/obj/effect/spawner/lootdrop/armory_contraband,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "aqC" = (

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -2920,6 +2920,9 @@
 /obj/item/poster/random_contraband,
 /obj/item/clothing/suit/armor/navyblue/russian,
 /obj/item/grenade/plastic/c4,
+/obj/effect/spawner/lootdrop/armory_contraband,
+/obj/effect/spawner/lootdrop/armory_contraband,
+/obj/effect/spawner/lootdrop/armory_contraband,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "aid" = (

--- a/_maps/map_files/TauStation/TauStation.dmm
+++ b/_maps/map_files/TauStation/TauStation.dmm
@@ -10471,6 +10471,9 @@
 	lootcount = 8;
 	name = "8maintenance loot spawner"
 	},
+/obj/effect/spawner/lootdrop/armory_contraband,
+/obj/effect/spawner/lootdrop/armory_contraband,
+/obj/effect/spawner/lootdrop/armory_contraband,
 /turf/open/floor/engine,
 /area/ai_monitored/security/armory)
 "dGE" = (


### PR DESCRIPTION
Изменения в карте сделаны по запросу на добавление спавнеров оружия в шкафчик с контрабандой (там, куда некуда было втулить шкафчик с контрабандой, запихнула в шкафчик с летальной аммуницией). Плюс ещё сверху перенесла на некоторые карты особые дормы с синдистейшена (космическую, ксено и тропическую комнаты)

Чейнджлог:
Cogstation
3 спавнера контрабандного оружия (в шкафчике с летальной аммуницей)

Boxstation
3 спавнера контрабандного оружия + дормы

Deltastation:
4 спавнера контрабандного оружия 

Festivestation:
3 спавнера контрабандного оружия 

Kilostation
3 спавнера контрабандного оружия (в шкафчике с летальной аммуницей)

Metastation
Дормы

Omegastation
4 спавнера контрабандного оружия

Pubbystation
3 спавнера контрабандного оружия

TauStation
3 спавнера контрабандного оружия