### PR TITLE
Конфиг на байпасс янтарного кода у боргов

### DIFF
--- a/code/controllers/configuration/entries/general.dm
+++ b/code/controllers/configuration/entries/general.dm
@@ -84,6 +84,8 @@
 
 /datum/config_entry/flag/disable_secborg	// disallow secborg module to be chosen.
 
+/datum/config_entry/flag/bypass_secborg_code	//allow secborg module to be chosen at roundstart without red alertcode
+
 /datum/config_entry/flag/disable_peaceborg
 
 /datum/config_entry/flag/economy	//money money money money money money money money money money money money

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -144,7 +144,7 @@
 		to_chat(src,"<span class='userdanger'>ERROR: Module installer reply timeout. Please check internal connections.</span>")
 		return
 
-	if(!CONFIG_GET(flag/disable_secborg) && GLOB.security_level < CONFIG_GET(number/minimum_secborg_alert))
+	if(!CONFIG_GET(flag/disable_secborg) && GLOB.security_level < CONFIG_GET(number/minimum_secborg_alert) && !CONFIG_GET(flag/bypass_secborg_code))
 		to_chat(src, "<span class='notice'>NOTICE: Due to local station regulations, the security cyborg module and its variants are only available during [NUM2SECLEVEL(CONFIG_GET(number/minimum_secborg_alert))] alert and greater.</span>")
 
 	var/list/modulelist = list("Standard" = /obj/item/robot_module/standard, \
@@ -155,7 +155,7 @@
 	"Service" = /obj/item/robot_module/butler)
 	if(!CONFIG_GET(flag/disable_peaceborg))
 		modulelist["Peacekeeper"] = /obj/item/robot_module/peacekeeper
-	if(BORG_SEC_AVAILABLE)
+	if(BORG_SEC_AVAILABLE || CONFIG_GET(flag/bypass_secborg_code))
 		modulelist["Security"] = /obj/item/robot_module/security
 
 	var/input_module = input("Please, select a module!", "Robot", null, null) as null|anything in sortList(modulelist)

--- a/config/entries/general.txt
+++ b/config/entries/general.txt
@@ -131,6 +131,8 @@ ALLOW_AI_MULTICAM
 ## Uncomment to prevent the security cyborg module from being chosen
 #DISABLE_SECBORG
 
+## Uncomment to allow choose the security cyborg module in any alertcode
+#BYPASS_SECBORG_CODE
 
 ## Peacekeeper Borg ###
 ## Uncomment to prevent the peacekeeper cyborg module from being chosen


### PR DESCRIPTION
На данный момент отсутствие боргов в секурити - лишает нас просто тонны вкусного нонкона. Поэтому было принято решение вернуть боргам возможность с начала игры выбирать модуль секурити. 
Думал сначала просто анкомитнуть строчку, но решил сделать правильнее и добавил настройку в конфиг. 

Чтобы заработало - нужно в конфиге анкоммитнуть строчку байпасса. 
Следовательно в конфиге General строчку - #BYPASS_SECBORG_CODE изменить в BYPASS_SECBORG_CODE

Это можно даже коммитнуть на оригинальный Сплюрт, но не думаю, что им это нужно.