### PR TITLE
Убираем меняющий цвет волос реагент из списка распыления из вентиляции

### DIFF
--- a/code/modules/events/vent_clog.dm
+++ b/code/modules/events/vent_clog.dm
@@ -44,7 +44,7 @@
 		/datum/reagent/peaceborg_tire,
 		/datum/reagent/consumable/sodiumchloride,
 		/datum/reagent/consumable/ethanol/beer,
-		/datum/reagent/hair_dye,
+		/*/datum/reagent/hair_dye, bluemoon removal*/
 		/datum/reagent/consumable/sugar,
 		/datum/reagent/glitter/white,
 		/datum/reagent/growthserum,


### PR DESCRIPTION
# About The Pull Request

Отключение шанса выпадения реагента, изменяющего цвет причесок из вентиляции.

## Why It's Good For The Game

Игрок не может изменить прическу на тот цвет, который хочет в текущий момент. Для меня это оказалось шоком, честно говоря. Изменить возможно либо на случайный через химию, либо через волшебное педальное зеркало, либо наложив сверху модификатор цвета (и то это просто наложение без возвращение цвета).

## Pre-Merge Checklist

- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
