### PR TITLE
Уменьшаем радиус распространения звука удушья

### DIFF
--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -202,7 +202,7 @@
 			'sound/voice/gasp_male5.ogg',
 			'sound/voice/gasp_male6.ogg',
 			'sound/voice/gasp_male7.ogg'),
-		50, TRUE, extrarange = -13) //2 tiles around
+		10, TRUE, extrarange = -13) //2 tiles around
 //bluemoon add end
 /datum/emote/living/giggle
 	key = "giggle"

--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -179,15 +179,31 @@
 	message = "gasps!"
 	emote_type = EMOTE_AUDIBLE
 	stat_allowed = UNCONSCIOUS
-
+//bluemoon add start
 /datum/emote/living/gasp/run_emote(mob/user, params)
 	. = ..()
 	var/mob/living/carbon/C = user
 	if(user.gender == FEMALE)
-		playsound(C, pick('sound/voice/gasp_female1.ogg', 'sound/voice/gasp_female2.ogg', 'sound/voice/gasp_female3.ogg', 'sound/voice/gasp_female4.ogg', 'sound/voice/gasp_female5.ogg', 'sound/voice/gasp_female6.ogg', 'sound/voice/gasp_female7.ogg'), 50, 1)
+		playsound(C, pick(
+			'sound/voice/gasp_female1.ogg',
+			'sound/voice/gasp_female2.ogg',
+			'sound/voice/gasp_female3.ogg',
+			'sound/voice/gasp_female4.ogg',
+			'sound/voice/gasp_female5.ogg',
+			'sound/voice/gasp_female6.ogg',
+			'sound/voice/gasp_female7.ogg'),
+		10, TRUE, extrarange = -13) //2 tiles around
 	else
-		playsound(C, pick('sound/voice/gasp_male1.ogg', 'sound/voice/gasp_male2.ogg', 'sound/voice/gasp_male3.ogg', 'sound/voice/gasp_male4.ogg', 'sound/voice/gasp_male5.ogg', 'sound/voice/gasp_male6.ogg', 'sound/voice/gasp_male7.ogg'), 50, 1)
-
+		playsound(C, pick(
+			'sound/voice/gasp_male1.ogg',
+			'sound/voice/gasp_male2.ogg',
+			'sound/voice/gasp_male3.ogg',
+			'sound/voice/gasp_male4.ogg',
+			'sound/voice/gasp_male5.ogg',
+			'sound/voice/gasp_male6.ogg',
+			'sound/voice/gasp_male7.ogg'),
+		50, TRUE, extrarange = -13) //2 tiles around
+//bluemoon add end
 /datum/emote/living/giggle
 	key = "giggle"
 	key_third_person = "giggles"


### PR DESCRIPTION
# About The Pull Request

Снижение дальности распространения звука удушья вокруг до 3 тайлов, а также громкости.
https://discord.com/channels/875735187449847830/1058665181523218562/1058665181523218562 - апрув.

## Why It's Good For The Game

За 2 экранами от персонажа не будет слышно на полную громкость, как он задыхается. В условных техах всё ещё можно различить звук, если жертва лежит в нычке роли или неподалёку от стены.

## Pre-Merge Checklist

- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.

## Changelog

:cl: SishTis

balance: Дальность распространения звука удушья уменьшена до 3 тайлов вокруг персонажа.

/:cl:
