### PR TITLE
Убираем образование гааз copium при распылении афродизаков

### DIFF
--- a/modular_splurt/code/modules/reagents/chemistry/reagents/drug_reagents.dm
+++ b/modular_splurt/code/modules/reagents/chemistry/reagents/drug_reagents.dm
@@ -62,7 +62,7 @@
 		H.adjust_disgust(20)
 		to_chat(H, "<span class='warning'>I can't stand it anymore!</span>")
 	..()
-
+/* bluemoon removal start
 /datum/reagent/drug/copium/reaction_obj(obj/O, volume)
 	if ((!O) || (!volume))
 		return 0
@@ -74,3 +74,4 @@
 		var/temp = holder ? holder.chem_temp : T20C
 		T.atmos_spawn_air("copium=[volume];TEMP=[temp]")
 	return
+bluemoon removal end*/


### PR DESCRIPTION
# About The Pull Request

При ивенте с афродизиаками в атмосфере по всей станции больше не будет образовываться газ copium.

## Why It's Good For The Game

~~Cope about it.~~
Больше не ломается атмосфера на судне.

## Pre-Merge Checklist

- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.

## Changelog

:cl:
del: Газ copium больше не образуется при распаде афродизиака в атмосфере.
/:cl:
