### PR TITLE
Делаем аплоуд стратегической точкой

### DIFF
--- a/modular_bluemoon/strategical_upload/strategical_upload.dm
+++ b/modular_bluemoon/strategical_upload/strategical_upload.dm
@@ -1,0 +1,33 @@
+//makes upload consoles indestructible
+/obj/machinery/computer/upload/Initialize()
+	flags_1 |= NODECONSTRUCT_1
+	resistance_flags |= INDESTRUCTIBLE
+	. = ..()
+
+//disables upload circuits from loading before the game starts, basicly deletes the,
+/obj/item/circuitboard/computer/aiupload/New()
+	if(SSticker.current_state != GAME_STATE_PLAYING)
+		visible_message("<span class='warning'>[src] disapeears in a bluespace wormhole. Looks like someone doesn't want it to be crated so soon.")
+		qdel(src)
+	return
+	. = ..()
+
+/obj/item/circuitboard/computer/borgupload/New()
+	if(SSticker.current_state != GAME_STATE_PLAYING)
+		visible_message("<span class='warning'>[src] disapeears in a bluespace wormhole. Looks like someone doesn't want it to be crated so soon.")
+		qdel(src)
+		return
+	. = ..()
+
+//disables upload circuits printing, only admin-spawn
+/datum/design/board/aiupload
+	departmental_flags = 0
+
+/datum/design/board/borgupload
+	departmental_flags = 0
+
+//overrides lootdrop
+/obj/effect/spawner/lootdrop/techstorage/AI
+	loot = list(
+				/obj/item/circuitboard/aicore
+				)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -3869,6 +3869,7 @@
 #include "modular_bluemoon\SmiLeY\code\hilbertshotel_ghost.dm"
 #include "modular_bluemoon\SmiLeY\code\lavaland.dm"
 #include "modular_bluemoon\SmiLeY\code\game\objects\structures\signs\signs_flags.dm"
+#include "modular_bluemoon\strategical_upload\strategical_upload.dm"
 #include "modular_bluemoon\vagabond\code\modules\mob\dead\new_player\sprite_accessories\tails.dm"
 #include "modular_citadel\code\datums\components\souldeath.dm"
 #include "modular_citadel\code\datums\status_effects\chems.dm"


### PR DESCRIPTION
# About The Pull Request

1) Делаем консоли в аплоуде неразрушимыми и неразбираемыми.
2) Вставляем автоматическое удаление плат аплоуда (не смены закона) с карты, если не они не появляются в процессе игры (спавн админов, например).
3) Удаляем возможность печатать платы аплоуда из РНД.

## Why It's Good For The Game

Аплоуд теперь является стратегической точкой.

## A Port?

Нигде не видел такого.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.