### PR TITLE
фикс дубликат кеев в ямле для чеинжлога

### DIFF
--- a/tgui/packages/tgui/interfaces/Changelog.js
+++ b/tgui/packages/tgui/interfaces/Changelog.js
@@ -39,6 +39,27 @@ const icons = {
   unknown: { icon: 'info-circle', color: 'label' },
 };
 
+export function fixYAMLDuplicateKeys(yaml_text) {
+  let yaml_fix = {};
+  let currentKey = '';
+  for (let line of yaml_text.split('\n')) {
+    if (!line.match(/^[^\s]*:$/)) {
+      yaml_fix[currentKey].push(line);
+    } else {
+      currentKey = line;
+      if (!yaml_fix[currentKey]) {
+        yaml_fix[currentKey] = [];
+      }
+    }
+  }
+  let yaml_fixed_text = '';
+  for (let key of Object.keys(yaml_fix).sort()) {
+    yaml_fixed_text += key + '\n';
+    yaml_fixed_text += yaml_fix[key].join('\n') + '\n';
+  }
+  return yaml_fixed_text;
+}
+
 export class Changelog extends Component {
   constructor() {
     super();
@@ -88,7 +109,7 @@ export class Changelog extends Component {
             self.getData(date, attemptNumber + 1);
           }, timeout);
         } else {
-          self.setData(yaml.load(result, { schema: yaml.CORE_SCHEMA }));
+          self.setData(yaml.load(fixYAMLDuplicateKeys(result), { schema: yaml.CORE_SCHEMA }));
         }
       });
   };


### PR DESCRIPTION
<!-- FILLING OUT THIS FORM PROPERLY AND ADDING A PROPER CHANGELOG SECTION IS **NECESSARY** FOR PULL REQUESTS. IF THE INFORMATION IS NOT PROVIDED YOUR PR WILL NOT BE CONSIDERED FOR MERGING -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
<!-- If your PR is related to one of our discord suggestions, please add the number of this suggestion to this section. Or if you may, the message link of said suggestion-->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## A Port?

<!-- Just say if it is a port of something and link the original pr/commit/whatever. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->

## Changelog

:cl:
fix: исправлено, что чеинжлоги за последние два месяца не показывались
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
