### PR TITLE
Запрещаем ролям заходить в бесконечный отель

### DIFF
--- a/modular_bluemoon/SmiLeY/code/hilbertshotel_ghost.dm
+++ b/modular_bluemoon/SmiLeY/code/hilbertshotel_ghost.dm
@@ -6,6 +6,9 @@
 	. = ..()
 	if(.)
 		return
+	if(user.mind?.antag_datums)
+		to_chat(user, "<span class='warning'>Your special role doesn't allow you to enter infinity dormitory.</span>")
+		return //you can't enter infinity dormitories if you are a role
 	return promptAndCheckIn(user, user)
 
 /datum/map_template/ghost_cafe_rooms


### PR DESCRIPTION
Роли больше не могут заходить в бесконечный отель. Я заметил, что за один динамик несколько ролей использовали его для снаряжения, обсуждения планов с товарищами и других интересных действий. На одного в то время была погоня. Пруфы есть. Проверено на локалке.


![dreamseeker_fJ9C35dkPO](https://user-images.githubusercontent.com/78963858/226432080-772cdc03-93ca-44f6-9939-104cc14bb5fd.png)
