### PR TITLE
Делаем возможность делать тёмные цвета ещё темнее

### DIFF
--- a/code/__DEFINES/citadel_defines.dm
+++ b/code/__DEFINES/citadel_defines.dm
@@ -136,7 +136,7 @@
 #define DEFAULT_NO_EYE_STATE		"no_eye"
 
 //special species definitions
-#define MINIMUM_MUTANT_COLOR	"#202020" //this is how dark players mutant parts and skin can be
+#define MINIMUM_MUTANT_COLOR	"#030303" //this is how dark players mutant parts and skin can be
 
 //defines for different matrix sections
 #define MATRIX_RED			"red"


### PR DESCRIPTION

# About The Pull Request

На текущий момент, на сервере стоит ограничение, когда нельзя опустить тёмный цвет дальше определённого порога (по сути тёмно-серый в текущей вариации).

С учётом существующей убогости редактора, это не позволяет делать тёмные цвета на маркингах, которые в связи с крайне неприятной настройкой таковых у сплюрта всегда получаются крайне светлыми.

Обсидианово-чёрный цвет, например, крайне тяжело воссоздать. Это может быть интересно для некоторых татуировок на синтетиках (или продлении визора).

Этот ПР снимает ограничение, позволяя делать маркинги ещё более чёрными для компенсации редактора.

## Why It's Good For The Game

https://www.youtube.com/watch?v=ZyhrYis509A

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.

## Changelog

Убрано ограничение на темноту цвета при настройке персонажа. Можно сделать чёрный цвет действительно чёрным.