### PR TITLE
Игроки могут видеть голоса за режим или за карту

### DIFF
--- a/code/controllers/subsystem/vote.dm
+++ b/code/controllers/subsystem/vote.dm
@@ -439,7 +439,7 @@ SUBSYSTEM_DEF(vote)
 
 		SEND_SOUND(world, sound('sound/misc/notice2.ogg'))
 		reset()
-		display_votes = display //CIT CHANGE - adds obfuscated votes
+//		display_votes = display //CIT CHANGE - adds obfuscated votes
 		switch(vote_type)
 			if("restart")
 				choices.Add("Restart Round","Continue Playing")


### PR DESCRIPTION
# About The Pull Request

Включена возможность просмотра голосов за карту или за режим в процессе и в конце голосования.

## Why It's Good For The Game

В плане режима - точно видно, что интересно игрокам на данный момент в точном соотношении. Меньше нытья со стороны любителей одной из сторон и больше осознанности, если воут примерно 50/50.

Для карты - возможность сплотиться вокруг одной, когда выигрывает та, что не хочет никто.

## Pre-Merge Checklist
![AFrkbk4sxC](https://user-images.githubusercontent.com/78963858/233013132-fda161e0-7bd3-40ef-a867-15729ca51e55.png)
![kbYIWDdZPr](https://user-images.githubusercontent.com/78963858/233013144-5b3f7e24-4668-4729-8249-0ef6a05a0f56.png)


## Changelog

✅ Теперь игроки видят количество голосов за режим или за карту в процессе голосования.