### PR TITLE
Station time идёт с такой же скоростью, что и настоящее + Sol System Time

### DIFF
--- a/code/__BLUEMOONCODE/_DEFINES/time.dm
+++ b/code/__BLUEMOONCODE/_DEFINES/time.dm
@@ -1,0 +1,3 @@
+#define SOLAR_TIME(display_only, wtime) ((((wtime - SSticker.round_start_time) * SSticker.station_time_rate_multiplier) + SSticker.gametime_offset) % 864000) - (display_only? GLOB.timezoneOffset : 0)
+
+#define SOLAR_TIME_TIMESTAMP(format, wtime) time2text(SOLAR_TIME(TRUE, wtime), format)

--- a/code/__DEFINES/time.dm
+++ b/code/__DEFINES/time.dm
@@ -64,5 +64,8 @@ When using time2text(), please use "DDD" to find the weekday. Refrain from using
 #define WORLDTIME2TEXT(format) GAMETIMESTAMP(format, world.time)
 #define WORLDTIMEOFDAY2TEXT(format) GAMETIMESTAMP(format, world.timeofday)
 #define TIME_STAMP(format, showds) showds ? "[WORLDTIMEOFDAY2TEXT(format)]:[world.timeofday % 10]" : WORLDTIMEOFDAY2TEXT(format)
-#define STATION_TIME(display_only, wtime) ((((wtime - SSticker.round_start_time) * SSticker.station_time_rate_multiplier) + SSticker.gametime_offset) % 864000) - (display_only? GLOB.timezoneOffset : 0)
+//BLUEMOON CHANGE START
+#define STATION_TIME(display_only, wtime) (((wtime - SSticker.round_start_time) + SSticker.gametime_offset) % 864000) - (display_only? GLOB.timezoneOffset : 0)
+// WAS - #define STATION_TIME(display_only, wtime) ((((wtime - SSticker.round_start_time) * SSticker.station_time_rate_multiplier) + SSticker.gametime_offset) % 864000) - (display_only? GLOB.timezoneOffset : 0)
+//BLUEMOON CHANGE END
 #define STATION_TIME_TIMESTAMP(format, wtime) time2text(STATION_TIME(TRUE, wtime), format)

--- a/code/controllers/subsystem/statpanel.dm
+++ b/code/controllers/subsystem/statpanel.dm
@@ -27,6 +27,7 @@ SUBSYSTEM_DEF(statpanels)
 			"Round Time: [GAMETIMESTAMP("hh:mm:ss", round_time)]",
 			"Actual Round Timer: [time2text(real_round_time, "hh:mm:ss", 0)]", //A back up control to check the round time to see if round time has descyed as well as properly track round time
 			"Station Time: [STATION_TIME_TIMESTAMP("hh:mm:ss", world.time)]",
+			"Sol System Time: [SOLAR_TIME_TIMESTAMP("hh:mm:ss", world.time)]", //bluemoon add,
 			"Time Dilation: [round(SStime_track.time_dilation_current,1)]% AVG:([round(SStime_track.time_dilation_avg_fast,1)]%, [round(SStime_track.time_dilation_avg,1)]%, [round(SStime_track.time_dilation_avg_slow,1)]%)"
 		)
 

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -19,6 +19,7 @@
 #include "code\__byond_version_compat.dm"
 #include "code\_compile_options.dm"
 #include "code\world.dm"
+#include "code\__BLUEMOONCODE\_DEFINES\time.dm"
 #include "code\__DEFINES\_auxtools.dm"
 #include "code\__DEFINES\_globals.dm"
 #include "code\__DEFINES\_protect.dm"


### PR DESCRIPTION
# About The Pull Request

Всё в шапке.
Sol System Time - старое Station Time

## Why It's Good For The Game

https://discord.com/channels/875735187449847830/1083742509114601492/1083742509114601492
Sol System Time - довольно милое ролевое дополнение, на мой взгляд. Показывает, что время в аномальном секторе течёт иначе.


## Pre-Merge Checklist
![dreamseeker_mMSvXoiM67](https://user-images.githubusercontent.com/78963858/233036457-153a4845-1884-489b-ae03-624008f94729.png)


## Changelog

✅ Station Time теперь идёт с такой же скоростью, что и настоящее.
✅ Добавлено Sol System Time в основную вкладку. По сути старое Station time, показывает время в Солнечной Системе.