### PR TITLE
Зависимость времени голосования за режим от времени до начала игры

### DIFF
--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -528,7 +528,7 @@ SUBSYSTEM_DEF(ticker)
 			SSvote.initiate_vote("dynamic", "server", display = NONE, votesystem = SCORE_VOTING, forced = TRUE,vote_time = 20 MINUTES)
 		else
 			SSvote.initiate_vote("roundtype", "server", display = NONE, votesystem = PLURALITY_VOTING, forced=TRUE, \
-			vote_time = (CONFIG_GET(flag/modetier_voting) ? 1 MINUTES : 20 MINUTES))
+			vote_time = CONFIG_GET(number/lobby_countdown) * 10 - 20 SECONDS) //BLUEMOON CHANGE, WAS vote_time = (CONFIG_GET(flag/modetier_voting) ? 1 MINUTES : 20 MINUTES))
 
 /datum/controller/subsystem/ticker/Recover()
 	current_state = SSticker.current_state


### PR DESCRIPTION
# About The Pull Request

Теперь время для воута за режим (динамик/экста) - время до начала раунда (минус) 20 секунд.

## Why It's Good For The Game

Больше времени для того, чтобы зайти и успеть проголосовать.

## Pre-Merge Checklist
![dreamseeker_nvI2BEOHRQ](https://user-images.githubusercontent.com/78963858/233054871-c42543dd-f285-43fa-b9d2-7ea3fbb723c1.png)

## Changelog

✅ Игра теперь даёт практически всё время до начала игры для голосования за режим (динамик или эксту).