### PR TITLE
Изменение сообщения о прибытии/отбытии со станции

### DIFF
--- a/code/game/machinery/announcement_system.dm
+++ b/code/game/machinery/announcement_system.dm
@@ -17,12 +17,12 @@ GLOBAL_LIST_EMPTY(announcement_systems)
 	circuit = /obj/item/circuitboard/machine/announcement_system
 
 	var/obj/item/radio/headset/radio
-	var/arrival = "%PERSON прибывает на станцию как %RANK"
+	var/arrival = "На станцию прибывает %PERSON, %RANK."
 	var/arrivalToggle = TRUE
 	var/newhead = "%PERSON, %RANK, глава отдела."
 	var/newheadToggle = TRUE
 	var/cryostorage = "%PERSON, %RANK, уходит в криосон." // this shouldnt be changed
-	var/cryostorage_tele = "%PERSON, %RANK, был(-а) телепортирован(-а) на Аванпост Центрального Командования."   // you saying it hat man.
+	var/cryostorage_tele = "%PERSON, %RANK, телепортируется на аванпост ЦК."   // you saying it hat man.
 
 	var/greenlight = "Light_Green"
 	var/pinklight = "Light_Pink"


### PR DESCRIPTION
# About The Pull Request

Было: 
```
[Common] Автоматизированная Система Оповещений холодно констатирует, "Боб Клувня прибывает на станцию как Clown"
[Common] Автоматизированная Система Оповещений холодно констатирует, "Боб Клувня, Clown, был(-а) телепортирован(-а) на Аванпост Центрального Командования."
```
Стало:
```
[Common] Автоматизированная Система Оповещений холодно констатирует, "Боб Клувня, Clown, прибывает на станцию."
[Common] Автоматизированная Система Оповещений холодно констатирует, "Боб Клувня, Clown, телепортируется на аванпост ЦК."
```
## Why It's Good For The Game

Мне кажется, что так выглядит благозвучнее.

1) Отсутствуют скобочки, которые в нормальной речи выделить тяжело и неприятно для уха.
2) Сокращена длина сообщений, повышая смысловую часть и убирая воду.
3) "Прибывает на станцию как..." - странное сочетание, на мой взгляд.

## Changelog

✅ Немного изменены анонсы прибытия на станцию и телепортации на ЦК через крио-телепорт.