### PR TITLE
Подписываем глаза с особой геторохронией

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -698,6 +698,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 							if(left_eye_color != right_eye_color)
 								split_eye_colors = TRUE
 							dat += "<h3>Heterochromia</h3>"
+							dat += "<i>Eyes with special heterochromia: wide, big, bigcyclops, skrell.</i>"
 							dat += "</b><a style='display:block;width:100px' href='?_src_=prefs;preference=toggle_split_eyes;task=input'>[split_eye_colors ? "Enabled" : "Disabled"]</a>"
 							if(!split_eye_colors)
 								dat += "<h3>Eye Color</h3>"


### PR DESCRIPTION
# About The Pull Request

Под пунктом гетерохронии вручную указаны глаза, у которых в спрайтах есть особый визуальный стиль при включенной гетерохронии.

## Why It's Good For The Game

Гетерохрония у этих глаз - неочевидная фича, которую большинство явно не планирует использовать. Возможно, такое выделение поможет выбрать что-то новое.

Сравнение до:

<details>

![ID6S6LOF47](https://user-images.githubusercontent.com/78963858/234034935-1af02db0-d9a5-4a8e-9d89-955299f9b846.png)
</details>

И после (обращать внимание на пункт гетерохронии):

<details>

![4dcJhlgE78](https://user-images.githubusercontent.com/78963858/234034977-86009680-c6ec-4b72-a0a4-d63de94ad5fa.png)
</details>
