### PR TITLE
Убираем у карт агентов из лодаута возможность забирать доступ

### DIFF
--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -472,6 +472,11 @@
 /obj/item/card/id/syndicate/afterattack(obj/item/O, mob/user, proximity)
 	if(!proximity)
 		return
+//BLUEMOON ADDITION START
+	if(stationed)
+		to_chat(usr, "<span class='warning'>The card seems to have its microscanners removed, as nothing happens. You can't copy access with it.</span>")
+		return
+//BLUEMOON ADDITION END
 	if(istype(O, /obj/item/card/id))
 		var/obj/item/card/id/I = O
 		src.access |= I.access

--- a/modular_bluemoon/station_agents_cards/cards_id.dm
+++ b/modular_bluemoon/station_agents_cards/cards_id.dm
@@ -1,0 +1,5 @@
+/obj/item/card/id/syndicate
+	var/stationed = FALSE //убираем у "дружелюбных сотрудников синдиката из профессий на станции" возможность копировать доступ
+
+/obj/item/card/id/syndicate/no_access_copy
+	stationed = TRUE

--- a/modular_citadel/code/modules/client/loadout/__donator.dm
+++ b/modular_citadel/code/modules/client/loadout/__donator.dm
@@ -36,9 +36,9 @@
 	donator_group_id = DONATOR_GROUP_TIER_1
 
 /datum/gear/donator/agent_card
-	name = "Agent Card"
+	name = "Agent Card (without microscanners)" //BLUEMOON CHANGES
 	slot = ITEM_SLOT_BACKPACK
-	path = /obj/item/card/id/syndicate
+	path = /obj/item/card/id/syndicate/no_access_copy //BLUEMOON CHANGES
 	ckeywhitelist = list()
 	donator_group_id = DONATOR_GROUP_TIER_1
 

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -4089,6 +4089,7 @@
 #include "modular_bluemoon\SmiLeY\mob\living\simple_animal\hostile\grabbagmob.dm"
 #include "modular_bluemoon\SmiLeY\self_actualization_device\code\self_actualization_device.dm"
 #include "modular_bluemoon\SmiLeY\Syndie_edits\code\syndie_edits.dm"
+#include "modular_bluemoon\station_agents_cards\cards_id.dm"
 #include "modular_bluemoon\vagabond\code\beast_spirit.dm"
 #include "modular_bluemoon\vagabond\code\trenchcoats_and_shit.dm"
 #include "modular_bluemoon\vagabond\code\tyler_durden.dm"


### PR DESCRIPTION
Всё в шапке.

Убираем возможность у карт агентов из лодаута воровать доступ со станционных карт.

Причины следующие:
1) Вещь из лодаута влияет на игровой баланс + находится за пэйволом (каким бы он ни был). Это выглядит мерзко.

2) Доступ клянчат. Его дают. Ценность ГП падает.
Самые дружелюбные члены экипажа спокойно клянчат карты у отделов, чтобы получать себе аналог полного доступа. По итогу появляются различные ниндзи синдиката в шахтёрском МОДе с убер-скоростью из-за химикатов, которые сами же варят. И никак доступ их в этом не останавливает, т.к. 1 из 4 сотрудников в отделе точно окажется достаточно услужливым. Самое печальное, что этим пользуются достаточно робастные игроки, чтобы получать дополнительное преимущество на случай проблем - например, эту карту можно брать в динамик и будучи инженером, идти защищать станцию со всем необходимым доступом. 

3) Обесцениваются карты синдиката из аплинка. Это не хорошо.

Действие затрагивает только карты в лодауте и никакие более. На иммерсивность влиять не должно - оперативники всё ещё могут писать глупости в имя и должность на карте, как и менять её облик.

Пруфы тестов:
![dreamseeker_qV46UHGbOI](https://github.com/SmiLeYre/BlueMoon-Station-13/assets/78963858/6cc10249-76b9-4305-bf71-bca88f861de6)
![dreamseeker_PzvP0XmE9M](https://github.com/SmiLeYre/BlueMoon-Station-13/assets/78963858/092c4a8b-ef51-446c-a0af-e872144076d6)

Что заставило сделать ПР:

![dreamseeker_w2h2nJOfIs](https://github.com/SmiLeYre/BlueMoon-Station-13/assets/78963858/6d6e10c9-eda7-4eae-9ce1-b7f3f5ed94a8)
