### PR TITLE
Rundown#1

### DIFF
--- a/_maps/RandomRuins/LavaRuins/bluemoon/lavaland_surface_syndicate_base1_bluemoon.dmm
+++ b/_maps/RandomRuins/LavaRuins/bluemoon/lavaland_surface_syndicate_base1_bluemoon.dmm
@@ -198,6 +198,7 @@
 /obj/item/gun/ballistic/revolver/syndicate,
 /obj/item/ammo_box/a357,
 /obj/item/ammo_box/a357,
+/obj/item/radio/headset/syndicate/alt,
 /turf/open/floor/wood,
 /area/ruin/lavaland/unpowered/deepspaceone/cargo)
 "br" = (
@@ -863,7 +864,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
-/obj/machinery/mineral/equipment_vendor,
+/obj/machinery/mineral/equipment_vendor/golem,
 /turf/open/floor/plasteel,
 /area/ruin/lavaland/unpowered/deepspaceone/cargo)
 "fN" = (
@@ -2386,6 +2387,7 @@
 /obj/structure/sign/flag/syndicate{
 	pixel_y = 33
 	},
+/obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/open/floor/plasteel/dark,
 /area/ruin/lavaland/unpowered/deepspaceone/cargo)
 "rl" = (
@@ -3158,11 +3160,6 @@
 /turf/open/floor/plating,
 /area/ruin/lavaland/unpowered/deepspaceone/engineering)
 "yf" = (
-/obj/structure/frame/machine{
-	anchored = 1;
-	state = 2;
-	icon_state = "box_1"
-	},
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
@@ -4104,30 +4101,12 @@
 /obj/structure/window/reinforced/survival_pod{
 	dir = 8
 	},
-/obj/item/ammo_box/magazine/m10mm{
-	pixel_x = 4;
-	pixel_y = -4
-	},
-/obj/item/ammo_box/magazine/m10mm{
-	pixel_x = 4;
-	pixel_y = -4
-	},
-/obj/item/ammo_box/magazine/m10mm{
-	pixel_x = 4;
-	pixel_y = -4
-	},
-/obj/item/ammo_box/magazine/m10mm{
-	pixel_x = 4;
-	pixel_y = -4
-	},
-/obj/item/ammo_box/magazine/sniper_rounds,
-/obj/item/ammo_box/magazine/sniper_rounds,
-/obj/item/ammo_box/magazine/sniper_rounds,
-/obj/item/ammo_box/magazine/sniper_rounds,
 /obj/machinery/light,
 /obj/structure/closet/crate/secure/gear{
 	req_access_txt = "150"
 	},
+/obj/item/storage/box/PDAs,
+/obj/item/storage/box/syndie_kit/chameleon,
 /turf/open/floor/plasteel/dark,
 /area/ruin/lavaland/unpowered/deepspaceone/cargo)
 "Fe" = (
@@ -4214,10 +4193,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/ruin/lavaland/unpowered/deepspaceone/medbay)
-"FC" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/turf/open/floor/plasteel/dark,
-/area/ruin/lavaland/unpowered/deepspaceone/main)
 "FE" = (
 /obj/structure/bed,
 /obj/item/bedsheet/brown,
@@ -4351,6 +4326,7 @@
 /area/ruin/lavaland/unpowered/deepspaceone/dormitories)
 "Gu" = (
 /obj/effect/turf_decal/siding/thinplating/dark,
+/obj/structure/frame/computer,
 /turf/open/floor/plasteel,
 /area/ruin/lavaland/unpowered/deepspaceone/testlab)
 "GA" = (
@@ -4387,6 +4363,11 @@
 	},
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
+	},
+/obj/structure/frame/machine{
+	anchored = 1;
+	state = 2;
+	icon_state = "box_1"
 	},
 /turf/open/floor/plasteel,
 /area/ruin/lavaland/unpowered/deepspaceone/testlab)
@@ -4448,6 +4429,11 @@
 "Ht" = (
 /obj/effect/turf_decal/siding/thinplating/dark/corner{
 	dir = 8
+	},
+/obj/structure/frame/machine{
+	anchored = 1;
+	state = 2;
+	icon_state = "box_1"
 	},
 /turf/open/floor/plasteel,
 /area/ruin/lavaland/unpowered/deepspaceone/testlab)
@@ -4672,13 +4658,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/ruin/lavaland/unpowered/deepspaceone/dormitories)
-"IZ" = (
-/obj/structure/frame/computer{
-	dir = 4;
-	anchored = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/ruin/lavaland/unpowered/deepspaceone/testlab)
 "Jb" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer3{
 	dir = 6;
@@ -5554,12 +5533,13 @@
 /turf/closed/wall/r_wall/syndicate/nodiagonal,
 /area/ruin/lavaland/unpowered/deepspaceone/testlab)
 "OX" = (
+/obj/effect/turf_decal/siding/thinplating/dark,
 /obj/structure/frame/machine{
 	anchored = 1;
 	state = 2;
 	icon_state = "box_1"
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel,
 /area/ruin/lavaland/unpowered/deepspaceone/testlab)
 "Pd" = (
 /obj/structure/table,
@@ -5646,10 +5626,6 @@
 /area/ruin/lavaland/unpowered/deepspaceone/main)
 "PS" = (
 /obj/structure/safe,
-/obj/item/storage/box/syndie_kit/chameleon/ghostcafe{
-	desc = "It's a box, for storing things.";
-	name = "chameleon kit"
-	},
 /obj/item/clothing/suit/space/hardsuit/syndi/elite,
 /obj/item/dualsaber,
 /turf/open/floor/plasteel/dark,
@@ -5903,11 +5879,6 @@
 	},
 /area/ruin/lavaland/unpowered/deepspaceone/main)
 "Ru" = (
-/obj/structure/frame/machine{
-	anchored = 1;
-	state = 2;
-	icon_state = "box_1"
-	},
 /obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
@@ -7182,6 +7153,11 @@
 /area/ruin/lavaland/unpowered/deepspaceone/dormitories)
 "ZM" = (
 /obj/effect/turf_decal/siding/thinplating/dark/corner,
+/obj/structure/frame/machine{
+	anchored = 1;
+	state = 2;
+	icon_state = "box_1"
+	},
 /turf/open/floor/plasteel,
 /area/ruin/lavaland/unpowered/deepspaceone/testlab)
 "ZO" = (
@@ -7724,9 +7700,9 @@ ab
 ab
 HA
 Gu
-IZ
-OX
-OX
+EN
+EN
+EN
 Cl
 OW
 dO
@@ -7841,7 +7817,7 @@ ab
 ab
 ab
 HA
-Gu
+OX
 Ru
 yf
 ME
@@ -8611,7 +8587,7 @@ An
 Tx
 HL
 An
-FC
+An
 Wl
 qj
 WN

--- a/_maps/RandomRuins/SpaceRuins/BlueMoon/space_syndicate_base.dmm
+++ b/_maps/RandomRuins/SpaceRuins/BlueMoon/space_syndicate_base.dmm
@@ -259,7 +259,7 @@
 /turf/closed/wall/r_wall/syndicate,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge)
 "aW" = (
-/obj/machinery/porta_turret/syndicate/energy{
+/obj/machinery/porta_turret/syndicate{
 	dir = 6
 	},
 /turf/closed/wall/r_wall/syndicate/nodiagonal,
@@ -1025,7 +1025,9 @@
 	},
 /obj/structure/bed/dogbed,
 /obj/effect/decal/cleanable/oil,
-/mob/living/simple_animal/pet/syndifox,
+/mob/living/simple_animal/pet/syndifox{
+	faction = list(ROLE_SYNDICATE)
+	},
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge/admiral)
 "dI" = (
@@ -1617,8 +1619,9 @@
 /turf/open/floor/iron/white/diagonal,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/hydroponics)
 "gv" = (
-/obj/machinery/porta_turret/syndicate/energy{
-	dir = 5
+/obj/machinery/porta_turret/syndicate{
+	dir = 5;
+	faction = list("150","neutral")
 	},
 /turf/closed/wall/r_wall/syndicate,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge/vault)
@@ -3385,7 +3388,7 @@
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/engineering)
 "nO" = (
-/obj/machinery/porta_turret/syndicate/energy{
+/obj/machinery/porta_turret/syndicate{
 	dir = 9
 	},
 /turf/closed/wall/r_wall/syndicate/nodiagonal,
@@ -5345,7 +5348,7 @@
 /turf/open/floor/iron/white/textured_large,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/engineering)
 "vS" = (
-/obj/machinery/porta_turret/syndicate/energy,
+/obj/machinery/porta_turret/syndicate,
 /turf/closed/wall/r_wall/syndicate/nodiagonal,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge/vault)
 "vT" = (
@@ -8081,14 +8084,10 @@
 /turf/closed/wall/r_wall/syndicate/nodiagonal,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms/fitness)
 "IU" = (
-/obj/structure/frame/machine{
-	anchored = 1;
-	state = 2;
-	icon_state = "box_1"
-	},
 /obj/effect/turf_decal/siding/dark{
 	dir = 8
 	},
+/obj/machinery/autolathe/hacked,
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/security/armory)
 "IV" = (
@@ -8901,7 +8900,7 @@
 /turf/open/floor/iron/white/diagonal,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/medbay)
 "Mt" = (
-/obj/machinery/porta_turret/syndicate/energy{
+/obj/machinery/porta_turret/syndicate{
 	dir = 5
 	},
 /turf/closed/wall/r_wall/syndicate/nodiagonal,
@@ -13319,7 +13318,7 @@ wg
 "}
 (18,1,1) = {"
 wg
-Mt
+oG
 NB
 NB
 NB
@@ -14861,7 +14860,7 @@ wg
 wg
 EJ
 kx
-Mt
+oG
 bw
 zV
 Un

--- a/_maps/RandomRuins/SpaceRuins/listeningstation.dmm
+++ b/_maps/RandomRuins/SpaceRuins/listeningstation.dmm
@@ -779,6 +779,11 @@
 	},
 /area/ruin/space/has_grav/listeningstation)
 "bu" = (
+/mob/living/simple_animal/pet/penguin/baby{
+	faction = list(ROLE_SYNDICATE);
+	name = "Private";
+	desc = "Can I kiss the bride, Skipper?"
+	},
 /turf/open/floor/plasteel/white/side{
 	dir = 4
 	},
@@ -920,6 +925,15 @@
 	dir = 8
 	},
 /turf/open/floor/carpet/red,
+/area/ruin/space/has_grav/listeningstation)
+"dg" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer3{
+	dir = 4
+	},
+/obj/machinery/porta_turret/syndicate{
+	dir = 5
+	},
+/turf/closed/wall/r_wall,
 /area/ruin/space/has_grav/listeningstation)
 "di" = (
 /obj/structure/sink{
@@ -1104,6 +1118,12 @@
 /obj/machinery/microwave,
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/listeningstation)
+"iU" = (
+/obj/machinery/porta_turret/syndicate{
+	dir = 10
+	},
+/turf/closed/wall/r_wall,
+/area/ruin/space/has_grav/listeningstation)
 "jj" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
@@ -1208,6 +1228,14 @@
 	},
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/listeningstation)
+"nO" = (
+/mob/living/simple_animal/pet/penguin/emperor/shamebrero{
+	faction = list(ROLE_SYNDICATE);
+	name = "Skipper";
+	desc = "Just smile and wave, boys. Smile and wave..."
+	},
+/turf/open/floor/wood,
+/area/ruin/space/has_grav/listeningstation)
 "or" = (
 /obj/machinery/atmospherics/pipe/manifold/orange/visible{
 	dir = 8
@@ -1222,6 +1250,12 @@
 "oL" = (
 /obj/structure/table/optable,
 /turf/open/floor/plasteel/white/side,
+/area/ruin/space/has_grav/listeningstation)
+"oW" = (
+/obj/machinery/porta_turret/syndicate{
+	dir = 9
+	},
+/turf/closed/wall/r_wall,
 /area/ruin/space/has_grav/listeningstation)
 "po" = (
 /obj/structure/toilet{
@@ -1617,7 +1651,8 @@
 "DF" = (
 /mob/living/simple_animal/pet/penguin/emperor{
 	name = "Kowalski";
-	desc = "Analysis"
+	desc = "Analysis.";
+	faction = list(ROLE_SYNDICATE)
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -1846,6 +1881,12 @@
 	},
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/listeningstation)
+"Kk" = (
+/obj/machinery/porta_turret/syndicate{
+	dir = 6
+	},
+/turf/closed/wall/r_wall,
+/area/ruin/space/has_grav/listeningstation)
 "Kq" = (
 /obj/structure/bookcase/random/adult,
 /turf/open/floor/carpet/black,
@@ -1893,12 +1934,36 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/plasteel/dark,
 /area/ruin/space/has_grav/listeningstation)
+"KL" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/mob/living/simple_animal/pet/penguin/emperor{
+	faction = list(ROLE_SYNDICATE);
+	desc = "FISH!!!!!";
+	name = "Rico"
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/listeningstation)
 "KX" = (
 /obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/o2{
 	dir = 1;
 	piping_layer = 3
 	},
 /turf/open/floor/plating,
+/area/ruin/space/has_grav/listeningstation)
+"Lb" = (
+/obj/machinery/porta_turret/syndicate{
+	dir = 5
+	},
+/turf/closed/wall/r_wall,
 /area/ruin/space/has_grav/listeningstation)
 "Lu" = (
 /obj/effect/turf_decal/tile/neutral{
@@ -2024,6 +2089,25 @@
 	},
 /turf/open/floor/carpet/black,
 /area/ruin/space/has_grav/listeningstation)
+"Pd" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/turretid{
+	ailock = 1;
+	dir = 1;
+	icon_state = "control_kill";
+	lethal = 1;
+	name = "Base turret controls";
+	pixel_y = 30;
+	req_access = null;
+	req_access_txt = "150"
+	},
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/listeningstation)
 "Pg" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -2050,6 +2134,12 @@
 /obj/structure/table/wood,
 /obj/item/clothing/accessory/ring/syntech,
 /turf/open/floor/carpet/black,
+/area/ruin/space/has_grav/listeningstation)
+"Qh" = (
+/obj/machinery/porta_turret/syndicate{
+	dir = 1
+	},
+/turf/closed/wall/r_wall,
 /area/ruin/space/has_grav/listeningstation)
 "Qm" = (
 /obj/machinery/light/small,
@@ -2638,6 +2728,7 @@ JY
 hy
 ab
 ab
+oW
 ag
 ag
 ag
@@ -2645,8 +2736,7 @@ ag
 ag
 ag
 ag
-ag
-ag
+iU
 ab
 ab
 ab
@@ -2718,7 +2808,7 @@ ag
 az
 az
 az
-az
+nO
 az
 az
 az
@@ -2882,7 +2972,7 @@ ag
 ag
 ag
 ag
-ag
+iU
 ab
 ab
 ab
@@ -2902,7 +2992,7 @@ ab
 ab
 ab
 ab
-ag
+oW
 ag
 ag
 rw
@@ -2975,7 +3065,7 @@ aa
 aa
 aa
 aa
-ag
+Qh
 ag
 ag
 ag
@@ -2999,7 +3089,7 @@ ag
 ag
 ag
 ag
-ag
+iU
 ab
 ab
 ab
@@ -3020,7 +3110,7 @@ PW
 aq
 aZ
 ag
-bb
+Pd
 Vr
 aD
 ag
@@ -3192,7 +3282,7 @@ fK
 VE
 ag
 ag
-ag
+iU
 ab
 ab
 ab
@@ -3279,7 +3369,7 @@ aa
 aa
 aa
 aa
-ag
+Qh
 ag
 ag
 ag
@@ -3344,7 +3434,7 @@ eW
 QQ
 ag
 fL
-ag
+Kk
 ab
 ab
 ab
@@ -3396,7 +3486,7 @@ ab
 ab
 ag
 sb
-aF
+KL
 aF
 aE
 ag
@@ -3478,7 +3568,7 @@ aG
 ag
 ab
 ab
-ag
+Kk
 ag
 ag
 ag
@@ -3530,7 +3620,7 @@ ab
 ab
 ab
 ab
-aH
+dg
 ab
 ab
 TM
@@ -3547,9 +3637,9 @@ aa
 aa
 aa
 ab
-ag
+Lb
 ap
-ag
+Kk
 ab
 ab
 ab


### PR DESCRIPTION
# About The Pull Request

Minor rundown update.

## Why It's Good For The Game

Что добавлено/изменено:
*Пост прослушки:*
1)Ковальски нашёл своих собратьев.
2)Добавлены турели для защиты поста, по типу ДС-1.

*ДС-2:*
1)Энерго-турели заменены на полноценные, баллистические турели с ДС-1.
2)Фракция у лисы адмирала заменена на синдикатовскую.
3)За место корпуса с проводами, в арсенале теперь полноценный автолат.

*ДС-1:*
1)Бесполезные магазины для .50 винтовки и APS были заменены на пустые PDA с одним набором хамелеона(Набор из сейфа удален)
2)Вендор шахтера заменён на големскую версию, так как кто-то постоянно уничтожает/разбирает ради шутки плату из набора либератора в РнД.
3)Расположение корпусов в РнД было изменено, в теории, более удобное.
4)Агент коммуникаций получил свой illegal наушник, который так же есть и у Поста прослушки. Не совсем ясно, почему при выполнении в теории одной и той же работы, тот ограничен в такой экипировке.
## A Port?

No.

## Pre-Merge Checklist
- [X] You tested this on a local server.
- [X] This code did not runtime during testing.
- [X] You documented all of your changes.

## Changelog

:cl:
add: Listening post: Added syndicate ballistic turrets.
add: Listening post: Kowalski got his squadmates back.
fix: DS-2: Captain's pet is no longer considered InteQ faction.
tweak: DS-2: Armory now has a proper hacked autolathe rather than a machine frame.
tweak: DS-2: Energy turrets are replaced by superior ballistic turrets.
tweak: DS-1: RnD pre-made machine frames are located in much better position.
tweak: DS-1: Useless .50 cal rounds, as well as ammo for APS pistol(which DS-1's crew do not have) were replaced with chameleon kit with empty PDAs.
tweak: DS-1: Mining vendor was replaced with the golem's version, since somebody *always* deconstructs the one from the liberator's kit.
add: DS-1: Comms Agent has illegal headset in his locker, since he has at some point the same role as listening post ones.
/:cl: